### PR TITLE
Add support for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,26 @@
+{
+	"name": "pete-otaqui/ClipClop",
+	"type": "library",
+	"description": "A PHP option parser based on getopt()",
+	"keywords": ["ClipClop", "option parser"],
+	"homepage": "https://github.com/pete-otaqui/ClipClop",
+	"support": {
+		"issues": "https://github.com/pete-otaqui/ClipClop/issues",
+		"source": "https://github.com/pete-otaqui/ClipClop"
+	},
+	"authors": [{
+		"name": "Pete Otaqui",
+		"email": "pete@otaqui.com",
+		"homepage": "http://otaqui.com",
+		"role": "Developer"
+	}],
+	"license": [
+		"MIT"
+	],
+	"require": {
+		"php": ">=5.2.0"
+	},
+	"autoload": {
+		"classmap": ["ClipClop.php"]
+	}
+}


### PR DESCRIPTION
ClipClip can't currently be installed using composer, so I propose a composer.json is added to the project to allow it to be registered with packagist.