### PR TITLE
Packagist expects the package name to be lower case

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "pete-otaqui/ClipClop",
+	"name": "pete-otaqui/clip-clop",
 	"type": "library",
 	"description": "A PHP option parser based on getopt()",
 	"keywords": ["ClipClop", "option parser"],


### PR DESCRIPTION
Apologies - packagist expects package names to be lowercase, so I've lowercased it and added a hyphen in composer.json
